### PR TITLE
Create message entity on events

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
@@ -46,6 +46,13 @@ public class MessageAsyncListener {
 
         TransactionUtil.handle(() -> {
             // TODO (Kyungmin): Create a message entity for the assignment
+            Message message = new Message();
+            message.setType(MessageType.DOCUMENT_ASSIGNED);
+            message.setDocumentId(event.getDocumentId());
+            message.setSenderId(event.getUserId());
+            message.setReceiverId(event.getOwnerId());
+            MessageDao messageDao = new MessageDao();
+            messageDao.create(message);
 
             sendUnreadCount(event.getAssigneeId());
         });
@@ -63,6 +70,13 @@ public class MessageAsyncListener {
 
         TransactionUtil.handle(() -> {
             // TODO (Kyungmin): Create a message entity for the comment
+            Message message = new Message();
+            message.setType(MessageType.DOCUMENT_COMMENTED);
+            message.setDocumentId(event.getDocumentId());
+            message.setSenderId(event.getUserId());
+            message.setReceiverId(event.getOwnerId());
+            MessageDao messageDao = new MessageDao();
+            messageDao.create(message);
 
             sendUnreadCount(event.getOwnerId());
         });
@@ -82,6 +96,13 @@ public class MessageAsyncListener {
 
         TransactionUtil.handle(() -> {
             // TODO (Kyungmin): Create a message entity for the review
+            Message message = new Message();
+            message.setType(MessageType.DOCUMENT_REVIEWED);
+            message.setDocumentId(event.getDocumentId());
+            message.setSenderId(event.getUserId());
+            message.setReceiverId(event.getOwnerId());
+            MessageDao messageDao = new MessageDao();
+            messageDao.create(message);
 
             sendUnreadCount(event.getOwnerId());
         });

--- a/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
@@ -17,6 +17,9 @@ import com.sismics.docs.core.event.DocumentAssignedAsyncEvent;
 import com.sismics.docs.core.event.DocumentCommentedAsyncEvent;
 import com.sismics.docs.core.event.DocumentReviewedAsyncEvent;
 import com.sismics.docs.core.util.TransactionUtil;
+import com.sismics.docs.core.dao.MessageDao;
+import com.sismics.docs.core.constant.MessageType;
+import com.sismics.docs.core.model.jpa.Message;
 
 /**
  * Listener on messages.

--- a/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
@@ -53,7 +53,7 @@ public class MessageAsyncListener {
             message.setType(MessageType.DOCUMENT_ASSIGNED);
             message.setDocumentId(event.getDocumentId());
             message.setSenderId(event.getUserId());
-            message.setReceiverId(event.getOwnerId());
+            message.setReceiverId(event.getAssigneeId());
             MessageDao messageDao = new MessageDao();
             messageDao.create(message);
 


### PR DESCRIPTION
## Purpose

This PR resolves #24 to create message entity when a document is assigned/reviewed/commented and set them to the known values.

## Changes

Creates message entity and setting the sub values:

- `setType`: sets message type (DOCUMENT_ASSIGNED/DOCUMENT_REVIEWED/DOCUMENT_COMMENTED)
- `setDocumentId`: sets document id by calling `getDocumentId()` on given object
- `setSenderId`: sets sender id by calling `getUserId()` on inputted object
- `setReceiverId`: sets receiver id by calling `getOwnerId()` "

Then creating a messageDao object with this message

## Additional Comments
