### PR TITLE
Add inbox page and inbox tab to teedy navbar

### DIFF
--- a/docs-web/src/main/webapp/src/app/docs/app.js
+++ b/docs-web/src/main/webapp/src/app/docs/app.js
@@ -64,6 +64,24 @@ angular.module('docs',
         }
       }
     })
+    .state('inbox', {
+      url: '/inbox',
+      abstract: true,
+      views: {
+        'page': {
+          templateUrl: 'partial/docs/inbox.html',
+          controller: 'Inbox'
+        }
+      }
+    })
+    .state('inbox.default', {
+      url: '',
+      views: {
+        'tag': {
+          templateUrl: 'partial/docs/inbox.default.html'
+        }
+      }
+    })
     .state('settings', {
       url: '/settings',
       abstract: true,
@@ -418,6 +436,9 @@ angular.module('docs',
         }
       }
     });
+
+  // Testing if page url is correct, if it does not route correctly, user is sent to main page
+  $urlRouterProvider.otherwise("/document");
 
   // Configuring Restangular
   RestangularProvider.setBaseUrl('../api');

--- a/docs-web/src/main/webapp/src/app/docs/controller/inbox/Inbox.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/inbox/Inbox.js
@@ -1,0 +1,7 @@
+'use strict';
+
+/**
+ * Inbox controller.
+ */
+angular.module('docs').controller('Inbox', function($scope, Restangular) {
+});

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -151,7 +151,7 @@
           <!--Added a new icon that is a drop down inbox for the user, guests cannot see inbox
             ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->
           <li ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'">
-            <a href="#/inbox"><span class="fas fa-cog"></span> Inbox</a>
+            <a href="#/inbox"> Inbox</a>
           </li>
           <li>
             <a href="{{ userInfo.username == 'guest' ? '#/user/guest' : '#/settings/account' }}"

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -77,6 +77,7 @@
     <script src="app/docs/controller/document/ModalFileVersions.js" type="text/javascript"></script>
     <script src="app/docs/controller/tag/Tag.js" type="text/javascript"></script>
     <script src="app/docs/controller/tag/TagEdit.js" type="text/javascript"></script>
+    <script src="app/docs/controller/inbox/Inbox.js" type="text/javascript"></script>
     <script src="app/docs/controller/settings/Settings.js" type="text/javascript"></script>
     <script src="app/docs/controller/settings/SettingsDefault.js" type="text/javascript"></script>
     <script src="app/docs/controller/settings/SettingsAccount.js" type="text/javascript"></script>
@@ -147,6 +148,11 @@
         </ul>
 
         <ul class="nav navbar-nav navbar-right" ng-show="!userInfo.anonymous">
+          <!--Added a new icon that is a drop down inbox for the user, guests cannot see inbox
+            ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->
+          <li ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'">
+            <a href="#/inbox"><span class="fas fa-cog"></span> Inbox</a>
+          </li>
           <li>
             <a href="{{ userInfo.username == 'guest' ? '#/user/guest' : '#/settings/account' }}"
                translate-attr="{ title: 'index.logged_as' }" translate-values="{ username: userInfo.username }">

--- a/docs-web/src/main/webapp/src/partial/docs/inbox.html
+++ b/docs-web/src/main/webapp/src/partial/docs/inbox.html
@@ -1,0 +1,1 @@
+testtxt

--- a/docs-web/src/main/webapp/src/partial/docs/inbox.html
+++ b/docs-web/src/main/webapp/src/partial/docs/inbox.html
@@ -1,1 +1,1 @@
-testtxt
+Inbox Skeleton


### PR DESCRIPTION
## Purpose

This pr resolves #12 and resolves #13 by creating an inbox tab that links to a new inbox page in the nav-bar of Teddy where users will eventually be able to view their messages

## Changes

Added the files (inbox.html, inbox.default.html, and inbox.js) into webapp and modified (app.js and index.html) to create a new skeleton page for an inbox and a new tab called Inbox in the right Teedy navbar that links to this skeleton page. 

## Additional Comments
