### PR TITLE
Connect unread message count to show on the navbar

### DIFF
--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
@@ -91,10 +91,12 @@ public class MessageResource extends BaseResource {
      * @apiError (client) ForbiddenError Access denied
      * @apiPermission user
      * @apiVersion 1.5.0
+     * 
+     * @param count Current number of unread messages
      */
     @GET
     @Path("unread_count")
-    public void getUnreadCount(@Suspended final AsyncResponse asyncResponse)
+    public void getUnreadCount(@QueryParam("count") Integer count, @Suspended final AsyncResponse asyncResponse)
             throws InterruptedException {
         if (!authenticate()) {
             throw new ForbiddenClientException();
@@ -103,7 +105,7 @@ public class MessageResource extends BaseResource {
         String userId = principal.getId();
         MessageDao messageDao = new MessageDao();
         int unreadCount = messageDao.getUnreadMsgCount(userId);
-        if (unreadCount > 0) {
+        if (unreadCount > 0 && unreadCount != count) {
             JsonObject responseObj = Json.createObjectBuilder().add("count", unreadCount).build();
             asyncResponse.resume(Response.ok().entity(responseObj).build());
         } else if (MessageAsyncListener.isClientRegistered(userId)) {

--- a/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
@@ -3,7 +3,7 @@
 /**
  * Navigation controller.
  */
-angular.module('docs').controller('Navigation', function($scope, $state, $stateParams, $rootScope, User) {
+angular.module('docs').controller('Navigation', function($scope, $state, $stateParams, $rootScope, User, Restangular) {
   User.userInfo().then(function(data) {
     $rootScope.userInfo = data;
     if (data.anonymous) {
@@ -18,7 +18,14 @@ angular.module('docs').controller('Navigation', function($scope, $state, $stateP
     }
   });
 
-  $scope.unreadCount = 1;
+  $scope.unreadCount = 0;
+  async function getUnreadMessageCount() {
+    let response = await Restangular.one("messages", "unread_count").get({count: $scope.unreadCount});
+    $scope.unreadCount = response.count;
+    await getUnreadMessageCount();
+  }
+
+  getUnreadMessageCount();
 
   /**
    * User logout.

--- a/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
@@ -18,6 +18,8 @@ angular.module('docs').controller('Navigation', function($scope, $state, $stateP
     }
   });
 
+  $scope.unreadCount = 1;
+
   /**
    * User logout.
    */

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -151,7 +151,7 @@
           <!--Added a new icon that is a drop down inbox for the user, guests cannot see inbox
             ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->
           <li ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'">
-            <a href="#/inbox"> Inbox</a>
+            <a href="#/inbox"> Inbox {{ unreadCount }}</a>
           </li>
           <li>
             <a href="{{ userInfo.username == 'guest' ? '#/user/guest' : '#/settings/account' }}"

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -149,9 +149,12 @@
 
         <ul class="nav navbar-nav navbar-right" ng-show="!userInfo.anonymous">
           <!--Added a new icon that is a drop down inbox for the user, guests cannot see inbox
-            ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->
+            ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->        
           <li ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'">
-            <a href="#/inbox"> Inbox {{ unreadCount }}</a>
+            <a href="#/inbox">Inbox
+              <p style="display: inline; border-radius: 50%; background-color: red; padding: 3px 6px; color: white;"
+              ng-if="unreadCount != 0"> {{ unreadCount }}</p> 
+            </a>
           </li>
           <li>
             <a href="{{ userInfo.username == 'guest' ? '#/user/guest' : '#/settings/account' }}"


### PR DESCRIPTION
## Purpose

This PR resolves #29 of adding flash notification of the number of unread messages. We want to show the number of unread messages count with something that could catch the user's eyes

## Changes

- Enabled Long-Polling on the Navigations.js file to enable the real time update of the unread messages.
- Added styles to show the unread message count
- 
## Additional Comments
