### PR TITLE
Add document ID to the message dto object

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/MessageDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/MessageDao.java
@@ -97,7 +97,7 @@ public class MessageDao {
         Map<String, Object> parameterMap = new HashMap<String, Object>();
 
         StringBuilder sb = new StringBuilder(
-                "select m.MSG_ID_C as c0, m.MSG_TYPE_C as c1, u.USE_USERNAME_C as c2, m.MSG_ISREAD_B as c3, m.MSG_CREATETIME_D as c4 from T_MESSAGES m join T_USER u on u.USE_ID_C = m.MSG_IDSENDER_C");
+                "select m.MSG_ID_C as c0, m.MSG_TYPE_C as c1, u.USE_USERNAME_C as c2, m.MSG_IDDOCUMENT_C as c3, m.MSG_ISREAD_B as c4, m.MSG_CREATETIME_D as c5 from T_MESSAGES m join T_USER u on u.USE_ID_C = m.MSG_IDSENDER_C");
         criteriaList.add("m.MSG_IDRECEIVER_C = :userId");
         parameterMap.put("userId", userId);
 

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/MessageDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/MessageDao.java
@@ -128,6 +128,7 @@ public class MessageDao {
                     .setId((String) o[i++])
                     .setType(MessageType.valueOf((String) o[i++]))
                     .setSender((String) o[i++])
+                    .setDocumentId((String) o[i++])
                     .setIsRead((boolean) o[i++])
                     .setTimestamp((Date) o[i++]);
             messageDtoList.add(messageDto);

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/dto/MessageDto.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/dto/MessageDto.java
@@ -24,6 +24,11 @@ public class MessageDto {
     private String sender;
 
     /**
+     * Document ID.
+     */
+    private String documentId;
+
+    /**
      * Is read.
      */
     private boolean isRead;
@@ -57,6 +62,15 @@ public class MessageDto {
 
     public MessageDto setSender(final String sender) {
         this.sender = sender;
+        return this;
+    }
+
+    public String getDocumentId() {
+        return documentId;
+    }
+
+    public MessageDto setDocumentId(final String documentId) {
+        this.documentId = documentId;
         return this;
     }
 

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
@@ -91,10 +91,12 @@ public class MessageResource extends BaseResource {
      * @apiError (client) ForbiddenError Access denied
      * @apiPermission user
      * @apiVersion 1.5.0
+     * 
+     * @param count Current number of unread messages
      */
     @GET
     @Path("unread_count")
-    public void getUnreadCount(@Suspended final AsyncResponse asyncResponse)
+    public void getUnreadCount(@QueryParam("count") Integer count, @Suspended final AsyncResponse asyncResponse)
             throws InterruptedException {
         if (!authenticate()) {
             throw new ForbiddenClientException();
@@ -103,7 +105,7 @@ public class MessageResource extends BaseResource {
         String userId = principal.getId();
         MessageDao messageDao = new MessageDao();
         int unreadCount = messageDao.getUnreadMsgCount(userId);
-        if (unreadCount > 0) {
+        if (unreadCount > 0 && unreadCount != count) {
             JsonObject responseObj = Json.createObjectBuilder().add("count", unreadCount).build();
             asyncResponse.resume(Response.ok().entity(responseObj).build());
         } else if (MessageAsyncListener.isClientRegistered(userId)) {

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
@@ -74,6 +74,7 @@ public class MessageResource extends BaseResource {
                     .add("id", messageDto.getId())
                     .add("type", messageDto.getType().name())
                     .add("sender", messageDto.getSender())
+                    .add("documentId",messageDto.getDocumentId())
                     .add("isRead", messageDto.getIsRead())
                     .add("timestamp", dateFormat.format(messageDto.getTimestamp())));
         }

--- a/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
@@ -3,7 +3,7 @@
 /**
  * Navigation controller.
  */
-angular.module('docs').controller('Navigation', function($scope, $state, $stateParams, $rootScope, User) {
+angular.module('docs').controller('Navigation', function($scope, $state, $stateParams, $rootScope, User, Restangular) {
   User.userInfo().then(function(data) {
     $rootScope.userInfo = data;
     if (data.anonymous) {
@@ -18,7 +18,14 @@ angular.module('docs').controller('Navigation', function($scope, $state, $stateP
     }
   });
 
-  $scope.unreadCount = 1;
+  $scope.unreadCount = 0;
+  async function getUnreadMessageCount() {
+    let response = await Restangular.one("messages", "unread_count").get({count: $scope.unreadCount});
+    $scope.unreadCount = response.count;
+    await getUnreadMessageCount();
+  }
+
+  getUnreadMessageCount();
 
   /**
    * User logout.

--- a/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
+++ b/docs-web/src/main/webapp/src/app/docs/controller/Navigation.js
@@ -18,6 +18,8 @@ angular.module('docs').controller('Navigation', function($scope, $state, $stateP
     }
   });
 
+  $scope.unreadCount = 1;
+
   /**
    * User logout.
    */

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -151,7 +151,7 @@
           <!--Added a new icon that is a drop down inbox for the user, guests cannot see inbox
             ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->
           <li ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'">
-            <a href="#/inbox"> Inbox</a>
+            <a href="#/inbox"> Inbox {{ unreadCount }}</a>
           </li>
           <li>
             <a href="{{ userInfo.username == 'guest' ? '#/user/guest' : '#/settings/account' }}"

--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -149,9 +149,12 @@
 
         <ul class="nav navbar-nav navbar-right" ng-show="!userInfo.anonymous">
           <!--Added a new icon that is a drop down inbox for the user, guests cannot see inbox
-            ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->
+            ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'"-->        
           <li ui-sref-active="{ active: 'inbox.**' }" ng-show="userInfo.username != 'guest'">
-            <a href="#/inbox"> Inbox {{ unreadCount }}</a>
+            <a href="#/inbox">Inbox
+              <p style="display: inline; border-radius: 50%; background-color: red; padding: 3px 6px; color: white;"
+              ng-if="unreadCount != 0"> {{ unreadCount }}</p> 
+            </a>
           </li>
           <li>
             <a href="{{ userInfo.username == 'guest' ? '#/user/guest' : '#/settings/account' }}"


### PR DESCRIPTION
## Purpose

This PR resolves #32 by adding the document id that any action will be taken to the message dto, so the viewer can access the document through the id. 

## Changes

- Added the `documentId` object in the messageDTO file
- Added functions `getDocumentId` and `setDocumentId`
- Added the `documentId` when forming a Dto list in the `MessageDAO` file
- Added the documentId in the `MessageResource` on making the message object

## Additional Comments
