### PR TITLE
Fix multiple long polling from the same client

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/listener/async/MessageAsyncListener.java
@@ -125,6 +125,10 @@ public class MessageAsyncListener {
      *                      user
      */
     public static void registerClient(final String userId, final AsyncResponse asyncResponse) {
+        clients.computeIfPresent(userId, (k, v) -> {
+            v.cancel();
+            return null;
+        });
         clients.put(userId, asyncResponse);
     }
 

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/MessageResource.java
@@ -108,8 +108,6 @@ public class MessageResource extends BaseResource {
         if (unreadCount > 0 && unreadCount != count) {
             JsonObject responseObj = Json.createObjectBuilder().add("count", unreadCount).build();
             asyncResponse.resume(Response.ok().entity(responseObj).build());
-        } else if (MessageAsyncListener.isClientRegistered(userId)) {
-            asyncResponse.cancel();
         } else {
             MessageAsyncListener.registerClient(userId, asyncResponse);
         }


### PR DESCRIPTION
## Purpose

<!--- Provide a summary of the purpose of this PR --->

This PR resolves #35 by handling duplicate requests for the `GET /messages/unread_count` endpoint.

## Changes

<!--- Provide a summary of WHAT this PR is doing --->

When another request for the long polling comes in from the same client whose connection is already held by the server, the `MessageAsyncListener` now cancels the previous connection and replaces it with the new one. I've verified that the server does not throw a 503 error anymore when refreshing a Teedy page (and sending the API request) multiple times.

## Additional Comments
